### PR TITLE
Add polish translation

### DIFF
--- a/locale/pl/railloader.cfg
+++ b/locale/pl/railloader.cfg
@@ -29,14 +29,14 @@ railloader-disable=Wyłącz silosy kolejowe
 
 [railloader]
 railloader-configured-1=Ładowanie __1__.
-railunloader-configured-1=Unloading __1__.
+railunloader-configured-1=Rozładowanie __1__.
 railloader-configured-2=Ładowanie __1__ i __2__.
-railunloader-configured-2=Unloading __1__ i __2__.
+railunloader-configured-2=Rozładowanie __1__ i __2__.
 railloader-configured-3=Ładowanie __1__, __2__ i __3__.
-railunloader-configured-3=Unloading __1__, __2__ i __3__.
+railunloader-configured-3=Rozładowanie __1__, __2__ i __3__.
 railloader-configured-4=Ładowanie __1__, __2__, __3__ i __4__.
-railunloader-configured-4=Unloading __1__, __2__, __3__ i __4__.
+railunloader-configured-4=Rozładowanie __1__, __2__, __3__ i __4__.
 railloader-configured-5=Ładowanie __1__, __2__, __3__, __4__ i __5__.
-railunloader-configured-5=Unloading __1__, __2__, __3__, __4__ i __5__.
+railunloader-configured-5=Rozładowanie __1__, __2__, __3__, __4__ i __5__.
 
 invalid-position=Konstrukcja musi być dopasowana do toru.

--- a/locale/pl/railloader.cfg
+++ b/locale/pl/railloader.cfg
@@ -1,0 +1,42 @@
+[entity-name]
+railloader-placement-proxy=Silos kolejowy
+railunloader-placement-proxy=Zsyp rozładunkowy
+railloader-chest=Silos kolejowy
+railunloader-chest=Zsyp rozładunkowy
+railloader-inserter=Silos kolejowy
+railunloader-inserter=Zsyp rozładunkowy
+railloader-rail=Tor silosu kolejowego
+
+[entity-description]
+railloader-rail=Zostanie usunięte gdy ładowarka będzie usunięta, a tor będzie wolny.
+
+[technology-name]
+railloader=Silosy kolejowe
+
+[technology-description]
+railloader=Maszyny pozwalające na szybki załadunek i rozładunek wagonów typu hopper z zsypem dolnym.
+
+[mod-setting-name]
+railloader-allowed-items=Dozwolone przedmioty
+railloader-show-configuration-messages=Pokaż wiadomości konfiguracyjne
+
+[mod-setting-description]
+railloader-allowed-items=Rodzaje materiałów, które moga być obsługiwane przez silosy.\n\nTa konfiguracja jest sprawdzana gdy pociąg wjeżdża na stację.
+railloader-show-configuration-messages=Określa czy w momencie zmiany rodzaju ładowanego/rozładowywanego materiału powinna pojawić się informacja.
+
+[virtual-signal-name]
+railloader-disable=Wyłącz silosy kolejowe
+
+[railloader]
+railloader-configured-1=Ładowanie __1__.
+railunloader-configured-1=Unloading __1__.
+railloader-configured-2=Ładowanie __1__ i __2__.
+railunloader-configured-2=Unloading __1__ i __2__.
+railloader-configured-3=Ładowanie __1__, __2__ i __3__.
+railunloader-configured-3=Unloading __1__, __2__ i __3__.
+railloader-configured-4=Ładowanie __1__, __2__, __3__ i __4__.
+railunloader-configured-4=Unloading __1__, __2__, __3__ i __4__.
+railloader-configured-5=Ładowanie __1__, __2__, __3__, __4__ i __5__.
+railunloader-configured-5=Unloading __1__, __2__, __3__, __4__ i __5__.
+
+invalid-position=Konstrukcja musi być dopasowana do toru.


### PR DESCRIPTION
Complete polish translation of this mode. 

### Note for reviewer

In Polish language there is no one word name for machines that bulk load and unload hopper wagon. I used words `silos` for loader and `zsyp` for unloader. Technically `zsyp` is a part of hopper wagon not machine for unloading.