### PR TITLE
Fix crash related to reviving ghost

### DIFF
--- a/ghostconnections.lua
+++ b/ghostconnections.lua
@@ -17,7 +17,7 @@ function M.get_connections(entity)
 
   local out = {}
   for _, ghost in pairs(ghosts) do
-    for _, ccd in pairs(ghost.circuit_connection_definitions) do
+    for _, ccd in ipairs(ghost.circuit_connection_definitions) do
       if ccd.target_entity == entity then
         out[#out+1] = {
           wire = ccd.wire,


### PR DESCRIPTION
Reviving a rail loader ghost with extra circuit connected chests will crash because circuit_connection_definitions is an array instead of a table. Switch from pairs to ipairs.