### PR TITLE
Support Angel's addons storage mod

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,0 +1,4 @@
+-- Compatible with angel's addons storage
+if data.raw.technology["ore-silos"] then
+    table.insert(data.raw.technology["railloader"].prerequisites, "ore-silos")
+end

--- a/info.json
+++ b/info.json
@@ -6,7 +6,9 @@
 	"author": "Therax",
 	"homepage": "https://forums.factorio.com/viewtopic.php?f=93&t=56850",
 	"description": "Bulk train loader/unloader with buffer.",
-	"dependencies": [],
+	"dependencies": [
+		"? angelsaddons-storage >= 0.0.4"
+	],
 	"package": {
 		"ignore":[
 			"resources/*"

--- a/prototypes/recipe/railloader.lua
+++ b/prototypes/recipe/railloader.lua
@@ -1,6 +1,13 @@
 local Recipe = require "prototypes.recipe.Recipe"
 
 local possible_ingredients = {
+  -- Angel's addons storage
+  {
+    {"rail", 3},
+    {"iron-gear-wheel", 8},
+    {"silo", 1},
+    {"electronic-circuit", 2},
+  },
   -- xander-mod
   {
     {"rail", 3},

--- a/prototypes/recipe/railunloader.lua
+++ b/prototypes/recipe/railunloader.lua
@@ -1,6 +1,13 @@
 local Recipe = require "prototypes.recipe.Recipe"
 
 local possible_ingredients = {
+  -- Angel's addons storage
+  {
+    {"rail", 3},
+    {"iron-gear-wheel", 8},
+    {"silo", 1},
+    {"electronic-circuit", 2},
+  },
   -- xander-mod
   {
     {"rail", 3},


### PR DESCRIPTION
I think your rail loader like Angel's warehouse, so I added a tech prerequisite and modify the rail loader recipes.

![图片](https://user-images.githubusercontent.com/9391981/104619724-2a1eaa00-56c9-11eb-83a6-445dd175a765.png)
![图片](https://user-images.githubusercontent.com/9391981/104619803-3acf2000-56c9-11eb-946e-e6f8b0a9b909.png)

Of course, it is optional. If the player does not install Angel's addons storage, this will be ignored.

What do you think about it?