### PR TITLE
Add zircon to allowed items

### DIFF
--- a/bulk.lua
+++ b/bulk.lua
@@ -48,6 +48,8 @@ local items = {
   "sodium-hydroxide", "calcium-chloride", "lead-oxide", "alumina",
   "tungsten-oxide", "silicon-nitride", "cobalt-oxide", "silicon-carbide",
   "silver-nitrate", "silver-oxide",
+  -- bzzirconium
+  "zircon",
   -- hardCrafting
   "dirt",
   -- Krastorio


### PR DESCRIPTION
My Zirconium mod (bzzirconium) has a raw ore called zircon. I believe this change would enable it to work with bulk rail loaders.