### PR TITLE
Bz, Krastorio 2 and Rich Rock Requiem Additions

### DIFF
--- a/bulk.lua
+++ b/bulk.lua
@@ -48,8 +48,18 @@ local items = {
   "sodium-hydroxide", "calcium-chloride", "lead-oxide", "alumina",
   "tungsten-oxide", "silicon-nitride", "cobalt-oxide", "silicon-carbide",
   "silver-nitrate", "silver-oxide",
+  -- bzcarbon
+  "flake-graphite", "rough-diamond", "fullerenes", "nanotubes", "graphene",
+  -- bzlead
+  "enriched-lead", 
+  -- bzsilicon
+  "silica",
+  -- bztitanium
+  "enriched-titanium",
+  -- bztungsten
+  "enriched-tungsten", 
   -- bzzirconium
-  "zircon",
+  "zircon", "zirconia", "enriched-zircon", "zirconium-tungstate",  
   -- hardCrafting
   "dirt",
   -- Krastorio
@@ -58,7 +68,7 @@ local items = {
   "k-tantalum", "k-titanium", "menarite", "raw-imersite", "raw-menarite",
   "raw-minerals", "steel-billet",
   -- Krastorio2
-  "raw-rare-metals",
+  "raw-rare-metals", "lithium", "lithium-chloride", "silicon", "enriched-rare-metals",
   -- omnimatter
   "omnite",
   -- pycoalprocessing
@@ -91,6 +101,8 @@ local items = {
   "moondrop-diesel", "moondrop-fueloil", "moondrop-gas", "moondrop-kerosene",
   "moss", "rennea", "saps", "sea-sponge", "seaweed", "shell", "sporopollenin",
   "sugar", "yaedols", "nisi", "sic", "green-sic",
+  -- Rich Rocks Requiem
+  "rrr-rich-rocks", "rrr-raw-minerals", 
 }
 
 for i, item in ipairs(items) do

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,11 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.1.5
+Date: 2021-01-09
+  Changes:
+    - Added bulk item list for bz mods.
+    - Update bulk item list for Krastorio 2.
+    - Added bulk item list for Rich Rocks Requiem.
+---------------------------------------------------------------------------------------------------
 Version: 1.1.4
 Date: 2021-05-27
   Bugfixes:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "railloader",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"factorio_version": "1.1",
 	"title": "Bulk Rail Loader",
 	"author": "Therax",


### PR DESCRIPTION
This adds items for bulk.lua for brevven's set of mods missing Krastorio 2 items including those whose name got changed from K1 to K2 and Rich Rock Requiem a mod adds back the Rich Rocks from K1 back to K2 with support for Industrial Revolution. I have some best guesses bzcarbon as most pictures for the non ore items are on a microscopic level. I did find human scale pictures for fullerenes and nanotubes but not for the graphene itself (I usually found the equivalent of Space Exploration's Nanomaterials). 