### PR TITLE
change: put back mode of inserters

### DIFF
--- a/prototypes/entity/railloader.lua
+++ b/prototypes/entity/railloader.lua
@@ -80,6 +80,7 @@ data:extend{
     -- circuit_connector_sprites = circuitconnectors["railloader-inserter"].sprites,
     circuit_wire_max_distance = 0.5,
     draw_circuit_wires = false,
+    allow_custom_vectors = true
   },
 
   -- interactable inventory


### PR DESCRIPTION
The new LTN-like mod Cybersyn has a nifty wagon inventory filter mode. This is especially cool when you need to haul away "dirty" ores - ores that are made of different substances, such as in mixed patches or in the Hardcrafting mod. 
The Railloader would be a key element in this interaction. 
However, this does not work because of known problems: When one kind of material has been picked up, there are still leftovers in the hands of the inserters. The next time they are then unusable, because very likely another resource will be picked up. 

This patch should fix the problem as much as possible.
The idea is that the inserters, who shovel from the loader into the train, are simply turned around after their work is done. Now they put everything they have in their hands back into the loader chest (which of course has to have room for it, hence "as much as possible"). With the next train coming in, they are turned back to normal. 
For this I set the inserter prototype to "allow_custom_vectors". 
The logic for bending the inserters back and forth was built in minimally invasive and may not be 100% performant.
I've also left out configurability for now, but if you want it, I'll add it in (I don't really need it. I see no reason not to have that feature ;-) ).

