### PR TITLE
Fix to classify py graded ores as ores

### DIFF
--- a/bulk.lua
+++ b/bulk.lua
@@ -24,8 +24,7 @@ local patterns = {
     "%-gangue$",
     -- pyrawores
     "^grade%-",
-    "^low%-grade%-",
-    "^high%-grade%-",
+    "%-grade%-",
     "^reduced%-",
     "^sintered%-",
     "%-rejects$",


### PR DESCRIPTION
Fixes #47